### PR TITLE
Update path and site URL to resolve dead links

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  pathPrefix: "extensions.io",
+  pathPrefix: "extensions.quarkus.io",
 
   siteMetadata: {
     title: `Welcome to the Quarkiverse`,
@@ -7,8 +7,8 @@ module.exports = {
       name: `The Quarkus Team`,
       summary: `who are nice.`,
     },
-    description: `A prototype extensions cataloge.`,
-    siteUrl: `http://hollycummins.com/extensions.io`,
+    description: `A prototype extensions catalog.`,
+    siteUrl: `http://quarkus.io/extensions.quarkus.io`,
     social: {
       twitter: `quarkusio`,
     },


### PR DESCRIPTION
Most internal links on the page were broken by the links broken by rename and transfer of the git repo.