### PR TITLE
Include description in what we search

### DIFF
--- a/src/components/filters/filters.js
+++ b/src/components/filters/filters.js
@@ -21,8 +21,10 @@ const filterExtensions = (
   { regex, categoryFilter, platformFilter, versionFilter, compatibilityFilter }
 ) => {
   return extensions
-    .filter(extension =>
-      extension.name.toLowerCase().match(regex.toLowerCase())
+    .filter(
+      extension =>
+        extension.name.toLowerCase().match(regex.toLowerCase()) ||
+        extension.description?.toLowerCase().match(regex.toLowerCase())
     )
     .filter(
       extension =>

--- a/src/components/filters/filters.test.js
+++ b/src/components/filters/filters.test.js
@@ -10,6 +10,7 @@ describe("filters bar", () => {
 
   const alice = {
     name: "Alice",
+    description: "a nice person",
     metadata: {
       categories: ["lynx"],
       built_with_quarkus_core: "4.2",
@@ -65,12 +66,22 @@ describe("filters bar", () => {
       expect(newExtensions).not.toContain(fluffy)
     })
 
-    it("leaves in extensions which match the search filter", async () => {
+    it("leaves in extensions whose name match the search filter", async () => {
       const searchInput = screen.getByRole("textbox")
       await user.click(searchInput)
       await user.keyboard("Alice")
       expect(extensionsListener).toHaveBeenCalled()
       expect(newExtensions).toContain(alice)
+      expect(newExtensions).not.toContain(pascal)
+    })
+
+    it("leaves in extensions whose description match the search filter", async () => {
+      const searchInput = screen.getByRole("textbox")
+      await user.click(searchInput)
+      await user.keyboard("nice")
+      expect(extensionsListener).toHaveBeenCalled()
+      expect(newExtensions).toContain(alice)
+      expect(newExtensions).not.toContain(pascal)
     })
 
     it("is case insensitive in its searching", async () => {


### PR DESCRIPTION
Given the number of extensions is relatively small, I don't think we run too much risk of false positives if we include the description. It means, for example, if someone searches for "soap" they would find 'cxf', which is probably what they'd expect.