### PR TITLE
Switch over to displaying all extensions, not just non-platform ones

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,6 +1,8 @@
 const path = require(`path`)
 const axios = require("axios")
 const GithubSlugger = require("github-slugger")
+const { getPlatformId } = require("./src/components/util/pretty-platform")
+const { sortableName } = require("./src/components/util/sortable-name")
 
 const slugger = new GithubSlugger()
 
@@ -10,19 +12,21 @@ exports.sourceNodes = async ({
   createContentDigest,
 }) => {
   const { data } = await axios.get(
-    `https://registry.quarkus.io/client/non-platform-extensions?v=2.0.7`
+    `https://registry.quarkus.io/client/extensions/all`
   )
 
   data.extensions.forEach(extension => {
     actions.createNode({
+      metadata: {},
       ...extension,
       id: createNodeId(extension.name),
-      // slug: slugger(extension.name),
+      sortableName: sortableName(extension.name),
       slug: slugger.slug(extension.name, false),
       internal: {
         type: "extension",
         contentDigest: createContentDigest(extension),
       },
+      platforms: extension.origins.map(origin => getPlatformId(origin)),
     })
   })
 }
@@ -112,7 +116,7 @@ exports.createSchemaCustomization = ({ actions }) => {
     type ExtensionMetadata {
       categories: [String]
       built_with_quarkus_core: String
-
+      quarkus_core_compatibility: String
     }
     
     type SiteSiteMetadata {

--- a/src/components/extensions-list.js
+++ b/src/components/extensions-list.js
@@ -27,6 +27,11 @@ const ExtensionsList = ({ extensions }) => {
 
   // TODO why is this guard necessary?
   if (allExtensions) {
+    // Sort alphabetically, in the absence of a better idea (for now)
+    filteredExtensions.sort((a, b) =>
+      a.sortableName > b.sortableName ? 1 : -1
+    )
+
     return (
       <FilterableList className="extensions-list">
         <Filters extensions={allExtensions} filterAction={setExtensions} />

--- a/src/components/extensions-list.test.js
+++ b/src/components/extensions-list.test.js
@@ -9,27 +9,30 @@ describe("extension list", () => {
   const displayCategory = "Jewellery"
   const otherCategory = "snails"
 
-  const extensions = [
-    {
-      name: "JRuby",
-      slug: "jruby-slug",
-      metadata: { categories: [category] },
-      origins: ["bottom of the garden"],
-    },
-    {
-      name: "JDiamond",
-      slug: "jdiamond-slug",
-      metadata: { categories: [category] },
-      origins: ["a mine"],
-    },
+  const ruby = {
+    name: "JRuby",
+    sortableName: "ruby",
+    slug: "jruby-slug",
+    metadata: { categories: [category] },
+    platforms: ["bottom of the garden"],
+  }
+  const diamond = {
+    name: "JDiamond",
+    sortableName: "diamond",
+    slug: "jdiamond-slug",
+    metadata: { categories: [category] },
+    platforms: ["a mine"],
+  }
 
-    {
-      name: "Molluscs",
-      slug: "molluscs-slug",
-      metadata: { categories: [otherCategory] },
-      origins: ["bottom of the garden"],
-    },
-  ]
+  const molluscs = {
+    name: "Molluscs",
+    sortableName: "mollusc",
+    slug: "molluscs-slug",
+    metadata: { categories: [otherCategory] },
+    platforms: ["bottom of the garden"],
+  }
+
+  const extensions = [ruby, diamond, molluscs]
   const user = userEvent.setup()
 
   beforeEach(() => {
@@ -41,7 +44,7 @@ describe("extension list", () => {
   })
 
   it("renders the correct link", () => {
-    const link = screen.getAllByRole("link")[0] // Look at the first one
+    const link = screen.getAllByRole("link")[2] // Look at the third one - this is also testing the sorting
     expect(link).toBeTruthy()
     // Hardcoding the host is a bit risky but this should always be true in  test environment
     expect(link.href).toBe("http://localhost/jruby-slug")
@@ -53,21 +56,21 @@ describe("extension list", () => {
         const searchInput = screen.getByRole("textbox")
         await user.click(searchInput)
         await user.keyboard("octopus")
-        expect(screen.queryByText(extensions[0].name)).toBeFalsy()
+        expect(screen.queryByText(ruby.name)).toBeFalsy()
       })
 
       it("leaves in extensions which match the search filter", async () => {
         const searchInput = screen.getByRole("textbox")
         await user.click(searchInput)
         await user.keyboard("Ruby")
-        expect(screen.queryByText(extensions[0].name)).toBeTruthy()
+        expect(screen.queryByText(ruby.name)).toBeTruthy()
       })
 
       it("is case insensitive in its searching", async () => {
         const searchInput = screen.getByRole("textbox")
         await user.click(searchInput)
         await user.keyboard("ruby")
-        expect(screen.queryByText(extensions[0].name)).toBeTruthy()
+        expect(screen.queryByText(ruby.name)).toBeTruthy()
       })
     })
 
@@ -79,14 +82,14 @@ describe("extension list", () => {
       it("leaves in extensions which match category filter", async () => {
         fireEvent.click(screen.getByText(displayCategory))
 
-        expect(screen.queryByText(extensions[0].name)).toBeTruthy()
-        expect(screen.queryByText(extensions[1].name)).toBeTruthy()
+        expect(screen.queryByText(ruby.name)).toBeTruthy()
+        expect(screen.queryByText(diamond.name)).toBeTruthy()
       })
 
       it("filters out extensions which do not match the ticked category", async () => {
         fireEvent.click(screen.getByText(displayCategory))
 
-        expect(screen.queryByText(extensions[2].name)).toBeFalsy()
+        expect(screen.queryByText(molluscs.name)).toBeFalsy()
       })
     })
 
@@ -103,18 +106,18 @@ describe("extension list", () => {
       })
 
       it("leaves in extensions which match search filter and filters out extensions which do not match", async () => {
-        expect(screen.queryByText(extensions[0].name)).toBeTruthy()
-        expect(screen.queryByText(extensions[1].name)).toBeTruthy()
-        expect(screen.queryByText(extensions[2].name)).toBeTruthy()
+        expect(screen.queryByText(ruby.name)).toBeTruthy()
+        expect(screen.queryByText(diamond.name)).toBeTruthy()
+        expect(screen.queryByText(molluscs.name)).toBeTruthy()
 
         expect(screen.getByTestId("platform-form")).toHaveFormValues({
           platform: "",
         })
         await selectEvent.select(screen.getByLabelText(label), "A Mine")
 
-        expect(screen.queryByText(extensions[0].name)).toBeFalsy()
-        expect(screen.queryByText(extensions[1].name)).toBeTruthy()
-        expect(screen.queryByText(extensions[2].name)).toBeFalsy()
+        expect(screen.queryByText(ruby.name)).toBeFalsy()
+        expect(screen.queryByText(diamond.name)).toBeTruthy()
+        expect(screen.queryByText(molluscs.name)).toBeFalsy()
       })
     })
   })

--- a/src/components/filters/filters.js
+++ b/src/components/filters/filters.js
@@ -3,7 +3,6 @@ import { useEffect, useState } from "react"
 import styled from "styled-components"
 import CategoryFilter from "./category-filter"
 import Search from "./search"
-import CompatibilityFilter from "./compatibility-filter"
 import PlatformFilter from "./platform-filter"
 import VersionFilter from "./version-filter"
 
@@ -36,8 +35,10 @@ const filterExtensions = (
     .filter(
       extension =>
         platformFilter.length === 0 ||
-        (extension.origins &&
-          extension.origins?.find(origin => platformFilter.includes(origin)))
+        (extension.platforms &&
+          extension.platforms?.find(platform =>
+            platformFilter.includes(platform)
+          ))
     )
     .filter(
       extension =>
@@ -77,7 +78,7 @@ const Filters = ({ extensions, filterAction }) => {
   ]
 
   const platforms = [
-    ...new Set(extensions.map(extension => extension.origins).flat()),
+    ...new Set(extensions.map(extension => extension.platforms).flat()),
   ]
 
   const filteredExtensions = filterExtensions(extensions, filters)
@@ -101,10 +102,6 @@ const Filters = ({ extensions, filterAction }) => {
       <Search searcher={setRegex} />
       <VersionFilter extensions={extensions} filterer={setVersionFilter} />
       <CategoryFilter categories={categories} filterer={setCategoryFilter} />
-      <CompatibilityFilter
-        extensions={extensions}
-        filterer={setCompatibilityFilter}
-      />
       <PlatformFilter options={platforms} filterer={setPlatformFilter} />
     </FilterBar>
   )

--- a/src/components/filters/filters.test.js
+++ b/src/components/filters/filters.test.js
@@ -16,7 +16,7 @@ describe("filters bar", () => {
       built_with_quarkus_core: "4.2",
       quarkus_core_compatibility: "UNKNOWN",
     },
-    origins: ["Banff"],
+    platforms: ["Banff"],
   }
   const pascal = {
     name: "Pascal",
@@ -25,7 +25,7 @@ describe("filters bar", () => {
       built_with_quarkus_core: "63.5",
       quarkus_core_compatibility: "COMPATIBLE",
     },
-    origins: ["Toronto"],
+    platforms: ["Toronto"],
   }
   const fluffy = {
     name: "Fluffy",
@@ -34,7 +34,7 @@ describe("filters bar", () => {
       built_with_quarkus_core: "63.5",
       quarkus_core_compatibility: "COMPATIBLE",
     },
-    origins: ["Banff"],
+    platforms: ["Banff"],
   }
 
   const extensions = [alice, pascal, fluffy]
@@ -171,7 +171,7 @@ describe("filters bar", () => {
     })
   })
 
-  describe("compatibility filter", () => {
+  xdescribe("compatibility filter", () => {
     const label = "Compatibility"
 
     it("lists all the versions in the menu", async () => {

--- a/src/components/filters/platform-filter.js
+++ b/src/components/filters/platform-filter.js
@@ -1,6 +1,6 @@
 import * as React from "react"
 import DropdownFilter from "./dropdown-filter"
-import prettyPlatform from "../util/pretty-platform"
+import { prettyPlatformName } from "../util/pretty-platform"
 
 const PlatformFilter = ({ options, filterer }) => {
   return (
@@ -8,7 +8,7 @@ const PlatformFilter = ({ options, filterer }) => {
       displayLabel="Platform"
       filterer={filterer}
       options={options}
-      optionTransformer={prettyPlatform}
+      optionTransformer={prettyPlatformName}
     />
   )
 }

--- a/src/components/filters/platform-filter.test.js
+++ b/src/components/filters/platform-filter.test.js
@@ -30,8 +30,7 @@ describe("platform filter", () => {
   })
 
   describe("when options are available", () => {
-    const platformCode =
-      "io.bananas.registry:quarkus-non-platform-extensions:2.6.2:json:1.0-SNAPSHOT"
+    const platformCode = "quarkus-non-platform-extensions"
 
     const filterer = jest.fn()
     beforeEach(() => {

--- a/src/components/util/pretty-platform.js
+++ b/src/components/util/pretty-platform.js
@@ -3,19 +3,22 @@ const mappings = {
   "Quarkus Bom Quarkus Platform Descriptor": "Quarkus Platform",
 }
 
-const prettify = origin => {
+const getPlatformId = origin => {
   const elements = origin && origin.split(":")
-  const element = elements?.length > 1 ? elements[1] : origin
+  const id = elements?.length > 1 ? elements[1] : origin
 
-  const words = element?.split(/[ -]/)
+  return id
+}
+
+const prettyPlatformName = platformId => {
+  const words = platformId?.split(/[ -]/)
   const pretty = words
     ?.map(word => {
       return word[0].toUpperCase() + word.substring(1)
     })
     .join(" ")
 
-  // Now do some final mappings
   return mappings[pretty] ? mappings[pretty] : pretty
 }
 
-export default prettify
+module.exports = { prettyPlatformName, getPlatformId }

--- a/src/components/util/pretty-platform.test.js
+++ b/src/components/util/pretty-platform.test.js
@@ -1,27 +1,45 @@
-import prettyPlatform from "./pretty-platform"
+import { getPlatformId, prettyPlatformName } from "./pretty-platform"
 
 describe("platform name formatter", () => {
   it("handles arbitrary strings", () => {
-    expect(prettyPlatform("marshmallows")).toBe("Marshmallows")
+    expect(prettyPlatformName("marshmallows")).toBe("Marshmallows")
   })
 
   it("handles nulls", () => {
-    expect(prettyPlatform()).toBe()
+    expect(prettyPlatformName()).toBe()
+  })
+
+  it("handles non-platform platforms", () => {
+    expect(prettyPlatformName("quarkus-non-platform-extensions")).toBe(
+      "Non Platform Extensions"
+    )
+  })
+
+  it("handles quarkus core", () => {
+    expect(prettyPlatformName("quarkus-bom-quarkus-platform-descriptor")).toBe(
+      "Quarkus Platform"
+    )
+  })
+})
+
+describe("platform id extracter", () => {
+  it("handles arbitrary strings", () => {
+    expect(getPlatformId("marshmallows")).toBe("marshmallows")
+  })
+
+  it("handles nulls", () => {
+    expect(getPlatformId()).toBe()
   })
 
   it("handles non-platform platforms", () => {
     expect(
-      prettyPlatform(
+      getPlatformId(
         "io.quarkus.registry:quarkus-non-platform-extensions:2.0.7:json:1.0-SNAPSHOT"
       )
-    ).toBe("Non Platform Extensions")
+    ).toBe("quarkus-non-platform-extensions")
   })
 
-  it("handles quarkus core", () => {
-    expect(
-      prettyPlatform(
-        '"io.quarkus.platform:quarkus-bom-quarkus-platform-descriptor:2.1.0.Final:json:2.1.0.Final"'
-      )
-    ).toBe("Quarkus Platform")
+  it("handles arbitrary GAVs", () => {
+    expect(getPlatformId('"something:else:number:whatever:still"')).toBe("else")
   })
 })

--- a/src/components/util/sortable-name.js
+++ b/src/components/util/sortable-name.js
@@ -1,0 +1,8 @@
+const sortableName = name => {
+  return name
+    ?.toLowerCase()
+    .replace("quarkus", "")
+    .replace("-", "")
+    .replace(/ /g, "")
+}
+module.exports = { sortableName }

--- a/src/components/util/sortable-name.test.js
+++ b/src/components/util/sortable-name.test.js
@@ -1,0 +1,15 @@
+import { sortableName } from "./sortable-name"
+
+describe("name sort helper", () => {
+  it("handles arbitrary strings", () => {
+    expect(sortableName("Stuff")).toBe("stuff")
+  })
+
+  it("handles nulls", () => {
+    expect(sortableName()).toBe()
+  })
+
+  it("strips hyphens", () => {
+    expect(sortableName("Quarkus - CXF")).toBe("cxf")
+  })
+})

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -43,15 +43,15 @@ export const pageQuery = graphql`
     allExtension(sort: { fields: [name], order: DESC }) {
       nodes {
         name
+        sortableName
         description
         slug
         metadata {
           categories
-          built_with_quarkus_core
-          quarkus_core_compatibility
           guide
+          built_with_quarkus_core
         }
-        origins
+        platforms
       }
     }
   }


### PR DESCRIPTION
Now that https://github.com/quarkusio/registry.quarkus.io/pull/143 is merged and deployed, we can show all extensions. (Technically, it's *almost* all, because platforms other than the main quarkus platform are not included.)

This ended up being more work than just the URL rename. 

Some extensions, such as Spring Web, don’t have any metadata populated at all, so I provided a basic empty metadata (the alternative would be more guards everywhere).

Having the Quarkus Platform extensions in the data model exposed a problem with the current implementation of platform filtering. Many different origins share the same pretty platform name, and we deduplicate *before* mapping to the pretty name. I’ve fixed this by introducing a mapped platform in the GraphQL population stage.

The `quarkus_core_compatibility` field is no longer in the data model on the new endpoint, so figuring out what happened to it will require some investigation. It’s not as valuable or as widely populated as the name suggests, so I think it’s ok to live without it for the moment. I’ve raised #10 to track.

With more extensions, it was obvious that the sorting wasn’t ideal. Eventually we probably want to introduce some sort flippers (popularity, recency of release, name, etc), but for the moment I’ve just sorted by name. 