### PR TITLE
 Fix integration tests, and build forks

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       [ main ]
+  pull_request:
+    types: [ opened, synchronize, reopened, ready_for_review ]
 
 jobs:
   unit-test:
@@ -25,6 +27,25 @@ jobs:
         with:
           node-version: '14'
       - run: npm install
+      - run: npm run build
+        env:
+          NODE_ENV: production
+          GATSBY_ACTIVE_ENV: production
+      - run: npm run test:int
+        env:
+          CI: true
+
+  deploy:
+    # Only try and deploy on merged code
+    if: "(github.repository == 'quarkusio/extensions.quarkus.io' && endsWith(github.ref, '/main')) && github.event_name != 'pull_request'"
+    needs: [ unit-test, build ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '14'
+      - run: npm install
       - uses: enriikke/gatsby-gh-pages-action@v2
         with:
           access-token: ${{ secrets.ACCESS_TOKEN }}
@@ -33,6 +54,3 @@ jobs:
         env:
           NODE_ENV: production
           GATSBY_ACTIVE_ENV: production
-      - run: npm run test:int
-        env:
-          CI: true

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -5,7 +5,7 @@ on:
     branches:
       [ main ]
   pull_request:
-    types: [ opened, synchronize, reopened, ready_for_review ]
+    types: [ opened, synchronize, reopened ]
 
 jobs:
   unit-test:

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -37,7 +37,7 @@ jobs:
 
   deploy:
     # Only try and deploy on merged code
-    if: "(github.repository == 'quarkusio/extensions.quarkus.io' && endsWith(github.ref, '/main')) && github.event_name != 'pull_request'"
+    if: "github.repository == 'quarkusio/extensions.quarkus.io' && github.ref_name == 'main' && github.event_name == 'push'"
     needs: [ unit-test, build ]
     runs-on: ubuntu-latest
     steps:

--- a/test-integration/frontpage.test.js
+++ b/test-integration/frontpage.test.js
@@ -62,6 +62,9 @@ describe("main site", () => {
           page.waitForXPath('//*[text()="RabbitMQ Client"]')
         ).resolves.toBeTruthy()
         // ... but others should be gone
+
+        await page.waitForXPath('//*[text()="GitHub App"]', { hidden: true })
+
         let visible = true
         const gitHubApp = await page
           .waitForXPath('//*[text()="GitHub App"]', { timeout: 2000 })

--- a/test-integration/links.test.js
+++ b/test-integration/links.test.js
@@ -53,7 +53,6 @@ describe("site links", () => {
       // TODO remove these exemptions as soon as new releases with live guide links are made (the repos are correct, the releases are not)
       "https://quarkus.io/guides/mybatis-plus",
       "https://quarkus.io/guides/freemarker",
-      "https://quarkus.io/guides/jberet",
       "https://quarkus.io/guides/qson",
     ]
 

--- a/test-integration/links.test.js
+++ b/test-integration/links.test.js
@@ -48,7 +48,14 @@ describe("site links", () => {
       }
     })
 
-    const linksToSkip = ["https://twitter.com/quarkusio"]
+    const linksToSkip = [
+      "https://twitter.com/quarkusio",
+      // TODO remove these exemptions as soon as new releases with live guide links are made (the repos are correct, the releases are not)
+      "https://quarkus.io/guides/mybatis-plus",
+      "https://quarkus.io/guides/freemarker",
+      "https://quarkus.io/guides/jberet",
+      "https://quarkus.io/guides/qson",
+    ]
 
     // Go ahead and start the scan! As events occur, we will see them above.
     return await checker.check({


### PR DESCRIPTION
Resolves https://github.com/quarkusio/extensions.quarkus.io/issues/1 by running integration tests in their own stage, before attempting a deploy.

Resolves https://github.com/quarkusio/extensions.quarkus.io/issues/7 by adding an extra wait with `{hidden: true}`. I suspect the extension is a bit slower to disappear out of the dom in the servers. I don't totally trust the {hidden: true} so I've left in the original check as well.

Also (sigh) adds some exclusions for known dead links that have been waiting for releases for a couple of months.

Also updates it so that we test (but do not deploy, obvs) from PRs.