### PR TITLE
Hide unlisted extensions unless explicitly searched for

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -16,7 +16,7 @@ exports.sourceNodes = async ({
   )
 
   data.extensions.forEach(extension => {
-    actions.createNode({
+    const node = {
       metadata: {},
       ...extension,
       id: createNodeId(extension.name),
@@ -26,8 +26,17 @@ exports.sourceNodes = async ({
         type: "extension",
         contentDigest: createContentDigest(extension),
       },
-      platforms: extension.origins.map(origin => getPlatformId(origin)),
-    })
+      platforms: extension.origins?.map(origin => getPlatformId(origin)),
+    }
+    if (typeof node.metadata.unlisted === "string") {
+      if (node.metadata.unlisted.toLowerCase() === "true") {
+        node.metadata.unlisted = true
+      } else {
+        node.metadata.unlisted = false
+      }
+    }
+
+    actions.createNode(node)
   })
 }
 
@@ -117,6 +126,7 @@ exports.createSchemaCustomization = ({ actions }) => {
       categories: [String]
       built_with_quarkus_core: String
       quarkus_core_compatibility: String
+      unlisted: Boolean
     }
     
     type SiteSiteMetadata {

--- a/gatsby-node.test.js
+++ b/gatsby-node.test.js
@@ -1,0 +1,150 @@
+const axios = require("axios")
+jest.mock("axios")
+
+const { sourceNodes } = require("./gatsby-node")
+
+const createNode = jest.fn()
+const createNodeId = jest.fn()
+const createContentDigest = jest.fn()
+
+const actions = { createNode }
+
+describe("the main gatsby entrypoint", () => {
+  describe("for an extension with no data", () => {
+    const extension = {}
+
+    beforeAll(async () => {
+      axios.get = jest
+        .fn()
+        .mockReturnValue({ data: { extensions: [extension] } })
+
+      await sourceNodes({ actions, createNodeId, createContentDigest })
+    })
+
+    afterAll(() => {
+      jest.clearAllMocks()
+    })
+
+    it("creates a node and fills in empty metadata", () => {
+      expect(createNode).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: {},
+        })
+      )
+    })
+
+    it("creates an id", () => {
+      expect(createNodeId).toHaveBeenCalled()
+    })
+  })
+
+  describe("for an extension with unlisted", () => {
+    const extension = { metadata: { unlisted: true } }
+
+    beforeAll(async () => {
+      axios.get = jest
+        .fn()
+        .mockReturnValue({ data: { extensions: [extension] } })
+
+      await sourceNodes({ actions, createNodeId, createContentDigest })
+    })
+
+    afterAll(() => {
+      jest.clearAllMocks()
+    })
+
+    it("creates a node and fills the correct value for unlisted", () => {
+      expect(createNode).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: { unlisted: true },
+        })
+      )
+    })
+
+    it("creates an id", () => {
+      expect(createNodeId).toHaveBeenCalled()
+    })
+  })
+
+  describe("for an extension with unlisted set to false", () => {
+    const extension = { metadata: { unlisted: false } }
+
+    beforeAll(async () => {
+      axios.get = jest
+        .fn()
+        .mockReturnValue({ data: { extensions: [extension] } })
+
+      await sourceNodes({ actions, createNodeId, createContentDigest })
+    })
+
+    afterAll(() => {
+      jest.clearAllMocks()
+    })
+
+    it("creates a node and fills the correct value for unlisted", () => {
+      expect(createNode).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: { unlisted: false },
+        })
+      )
+    })
+  })
+
+  // in a handful of the extension yamls, the unlisted is a string, not a boolean. since this is a string, it drives graphQL made with type anxiety, unless we help.
+  describe("for an extension with unlisted as a string", () => {
+    const extension = { metadata: { unlisted: "true" } }
+
+    beforeAll(async () => {
+      axios.get = jest
+        .fn()
+        .mockReturnValue({ data: { extensions: [extension] } })
+
+      await sourceNodes({ actions, createNodeId, createContentDigest })
+    })
+
+    afterAll(() => {
+      jest.clearAllMocks()
+    })
+
+    it("creates a node and fills the correct value for unlisted", () => {
+      expect(createNode).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: { unlisted: true },
+        })
+      )
+    })
+
+    it("creates an id", () => {
+      expect(createNodeId).toHaveBeenCalled()
+    })
+  })
+
+  // this *really* shouldn't happen, but if we're doing string to boolean conversion, we need to check false; treating string false as true is a common bug.
+  describe("for an extension with unlisted as a false string", () => {
+    const extension = { metadata: { unlisted: "false" } }
+
+    beforeAll(async () => {
+      axios.get = jest
+        .fn()
+        .mockReturnValue({ data: { extensions: [extension] } })
+
+      await sourceNodes({ actions, createNodeId, createContentDigest })
+    })
+
+    afterAll(() => {
+      jest.clearAllMocks()
+    })
+
+    it("creates a node and fills the correct value for unlisted", () => {
+      expect(createNode).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: { unlisted: false },
+        })
+      )
+    })
+
+    it("creates an id", () => {
+      expect(createNodeId).toHaveBeenCalled()
+    })
+  })
+})

--- a/src/components/extension-card.js
+++ b/src/components/extension-card.js
@@ -14,7 +14,8 @@ const Card = styled(props => <Link {...props} />)`
   width: 220px;
   height: 490px;
   background: var(--white) 0 0 no-repeat padding-box;
-  border: 1px solid var(--grey-1);
+  border: ${props =>
+    props.$unlisted ? "1px solid var(--grey-0)" : "1px solid var(--grey-1)"};
   opacity: 1;
   display: flex;
   flex-direction: column;
@@ -31,7 +32,7 @@ const ExtensionName = styled.div`
   font-size: var(--font-size-24);
   font-weight: var(--font-weight-bold);
   letter-spacing: 0;
-  color: var(--grey-2);
+  color: ${props => (props.$unlisted ? "var(--grey-1)" : "var(--grey-2)")};
   opacity: 1;
   min-height: 66px;
 `
@@ -56,7 +57,7 @@ const ExtensionCategory = styled.div`
 
 const ExtensionCard = ({ extension }) => {
   return (
-    <Card to={extension.slug}>
+    <Card to={extension.slug} $unlisted={extension.metadata.unlisted}>
       <Logo>
         <StaticImage
           layout="constrained"
@@ -65,7 +66,9 @@ const ExtensionCard = ({ extension }) => {
           alt="The extension logo"
         />
       </Logo>
-      <ExtensionName>{extension.name}</ExtensionName>
+      <ExtensionName $unlisted={extension.metadata.unlisted}>
+        {extension.name}
+      </ExtensionName>
       <ExtensionDescription>{extension.description}</ExtensionDescription>
 
       {extension.metadata.categories &&

--- a/src/components/extension-card.test.js
+++ b/src/components/extension-card.test.js
@@ -3,29 +3,50 @@ import { render, screen } from "@testing-library/react"
 import ExtensionCard from "./extension-card"
 
 describe("extension card", () => {
-  const category = "jewellery"
-  const extension = {
-    name: "JRuby",
-    slug: "jruby-slug",
-    metadata: { categories: [category] },
-  }
+  describe("a normal extension", () => {
+    const category = "jewellery"
+    const extension = {
+      name: "JRuby",
+      slug: "jruby-slug",
+      metadata: { categories: [category] },
+    }
 
-  beforeEach(() => {
-    render(<ExtensionCard extension={extension} />)
+    beforeEach(() => {
+      render(<ExtensionCard extension={extension} />)
+    })
+
+    it("renders the extension name", () => {
+      expect(screen.getByText(extension.name)).toBeTruthy()
+    })
+
+    it("renders the correct link", () => {
+      const link = screen.getByRole("link")
+      expect(link).toBeTruthy()
+      // Hardcoding the host is a bit risky but this should always be true in  test environment
+      expect(link.href).toBe("http://localhost/jruby-slug")
+    })
+
+    it("renders the formatted category", () => {
+      expect(screen.getByText("Category: Jewellery")).toBeTruthy()
+    })
   })
 
-  it("renders the extension name", () => {
-    expect(screen.getByText(extension.name)).toBeTruthy()
-  })
+  describe("an unlisted extension", () => {
+    const category = "jewellery"
+    const extension = {
+      name: "JRuby",
+      slug: "jruby-slug",
+      metadata: { categories: [category], unlisted: true },
+    }
 
-  it("renders the correct link", () => {
-    const link = screen.getByRole("link")
-    expect(link).toBeTruthy()
-    // Hardcoding the host is a bit risky but this should always be true in  test environment
-    expect(link.href).toBe("http://localhost/jruby-slug")
-  })
+    beforeEach(() => {
+      render(<ExtensionCard extension={extension} />)
+    })
 
-  it("renders the formatted category", () => {
-    expect(screen.getByText("Category: Jewellery")).toBeTruthy()
+    // This is a weak test, because css variables don't turn up in the computed style, so we can't make assertions about the style
+    // leaving this here just to check nothing breaks
+    it("renders the extension name", () => {
+      expect(screen.getByText(extension.name)).toBeTruthy()
+    })
   })
 })

--- a/src/components/filters/filters.js
+++ b/src/components/filters/filters.js
@@ -19,41 +19,46 @@ const filterExtensions = (
   extensions,
   { regex, categoryFilter, platformFilter, versionFilter, compatibilityFilter }
 ) => {
-  return extensions
-    .filter(
-      extension =>
-        extension.name.toLowerCase().match(regex.toLowerCase()) ||
-        extension.description?.toLowerCase().match(regex.toLowerCase())
-    )
-    .filter(
-      extension =>
-        categoryFilter.length === 0 ||
-        extension.metadata.categories?.find(category =>
-          categoryFilter.includes(category.toLowerCase())
-        )
-    )
-    .filter(
-      extension =>
-        platformFilter.length === 0 ||
-        (extension.platforms &&
-          extension.platforms?.find(platform =>
-            platformFilter.includes(platform)
-          ))
-    )
-    .filter(
-      extension =>
-        versionFilter.length === 0 ||
-        (extension.metadata.built_with_quarkus_core &&
-          versionFilter.includes(extension.metadata.built_with_quarkus_core))
-    )
-    .filter(
-      extension =>
-        compatibilityFilter.length === 0 ||
-        (extension.metadata.quarkus_core_compatibility &&
-          compatibilityFilter.includes(
-            extension.metadata.quarkus_core_compatibility
-          ))
-    )
+  return (
+    extensions
+      // Exclude unlisted extensions, unless they happen to match a non-trivial search filter
+      // We don't need to check if the searches matches, because we do that below
+      .filter(extension => !extension.metadata.unlisted || regex.length > 2)
+      .filter(
+        extension =>
+          extension.name.toLowerCase().match(regex.toLowerCase()) ||
+          extension.description?.toLowerCase().match(regex.toLowerCase())
+      )
+      .filter(
+        extension =>
+          categoryFilter.length === 0 ||
+          extension.metadata.categories?.find(category =>
+            categoryFilter.includes(category.toLowerCase())
+          )
+      )
+      .filter(
+        extension =>
+          platformFilter.length === 0 ||
+          (extension.platforms &&
+            extension.platforms?.find(platform =>
+              platformFilter.includes(platform)
+            ))
+      )
+      .filter(
+        extension =>
+          versionFilter.length === 0 ||
+          (extension.metadata.built_with_quarkus_core &&
+            versionFilter.includes(extension.metadata.built_with_quarkus_core))
+      )
+      .filter(
+        extension =>
+          compatibilityFilter.length === 0 ||
+          (extension.metadata.quarkus_core_compatibility &&
+            compatibilityFilter.includes(
+              extension.metadata.quarkus_core_compatibility
+            ))
+      )
+  )
 }
 
 const Filters = ({ extensions, filterAction }) => {

--- a/src/components/filters/filters.test.js
+++ b/src/components/filters/filters.test.js
@@ -36,8 +36,18 @@ describe("filters bar", () => {
     },
     platforms: ["Banff"],
   }
+  const secret = {
+    name: "James Bond",
+    metadata: {
+      categories: ["moose"],
+      built_with_quarkus_core: "63.5",
+      quarkus_core_compatibility: "COMPATIBLE",
+      unlisted: true,
+    },
+    platforms: ["Banff"],
+  }
 
-  const extensions = [alice, pascal, fluffy]
+  const extensions = [alice, pascal, fluffy, secret]
 
   beforeEach(() => {
     render(
@@ -53,6 +63,10 @@ describe("filters bar", () => {
     expect(screen.getByText("Skunks")).toBeTruthy()
   })
 
+  it("excludes unlisted extensions", () => {
+    expect(newExtensions).not.toContain(secret)
+  })
+
   describe("searching", () => {
     const user = userEvent.setup()
 
@@ -64,6 +78,7 @@ describe("filters bar", () => {
       expect(newExtensions).not.toContain(alice)
       expect(newExtensions).not.toContain(pascal)
       expect(newExtensions).not.toContain(fluffy)
+      expect(newExtensions).not.toContain(secret)
     })
 
     it("leaves in extensions whose name match the search filter", async () => {
@@ -73,6 +88,7 @@ describe("filters bar", () => {
       expect(extensionsListener).toHaveBeenCalled()
       expect(newExtensions).toContain(alice)
       expect(newExtensions).not.toContain(pascal)
+      expect(newExtensions).not.toContain(secret)
     })
 
     it("leaves in extensions whose description match the search filter", async () => {
@@ -90,6 +106,42 @@ describe("filters bar", () => {
       await user.keyboard("alice")
       expect(extensionsListener).toHaveBeenCalled()
       expect(newExtensions).toContain(alice)
+    })
+
+    describe("for an unlisted extension", () => {
+      const user = userEvent.setup()
+
+      it("filters out unlisted extensions if the search string is too short to be meaningful", async () => {
+        const searchInput = screen.getByRole("textbox")
+        await user.click(searchInput)
+        await user.keyboard("j")
+        expect(extensionsListener).toHaveBeenCalled()
+        expect(newExtensions).not.toContain(alice)
+        expect(newExtensions).not.toContain(pascal)
+        expect(newExtensions).not.toContain(fluffy)
+        expect(newExtensions).not.toContain(secret)
+      })
+
+      it("shows unlisted extensions if the search string has a meaningful length", async () => {
+        const searchInput = screen.getByRole("textbox")
+        await user.click(searchInput)
+        await user.keyboard("jame")
+        expect(extensionsListener).toHaveBeenCalled()
+
+        expect(newExtensions).toContain(secret)
+
+        expect(newExtensions).not.toContain(alice)
+        expect(newExtensions).not.toContain(pascal)
+        expect(newExtensions).not.toContain(fluffy)
+      })
+
+      it("is case insensitive in its searching", async () => {
+        const searchInput = screen.getByRole("textbox")
+        await user.click(searchInput)
+        await user.keyboard("alice")
+        expect(extensionsListener).toHaveBeenCalled()
+        expect(newExtensions).toContain(alice)
+      })
     })
   })
 
@@ -113,6 +165,10 @@ describe("filters bar", () => {
       expect(extensionsListener).toHaveBeenCalled()
       expect(newExtensions).not.toContain(alice)
     })
+
+    it("excludes unlisted extensions", () => {
+      expect(newExtensions).not.toContain(secret)
+    })
   })
 
   describe("platform filter", () => {
@@ -134,6 +190,10 @@ describe("filters bar", () => {
       expect(newExtensions).not.toContain(alice)
       expect(newExtensions).toContain(pascal)
       expect(newExtensions).not.toContain(fluffy)
+    })
+
+    it("excludes unlisted extensions", () => {
+      expect(newExtensions).not.toContain(secret)
     })
   })
 
@@ -168,6 +228,10 @@ describe("filters bar", () => {
       expect(newExtensions).not.toContain(alice)
       expect(newExtensions).toContain(pascal)
       expect(newExtensions).toContain(fluffy)
+    })
+
+    it("excludes unlisted extensions", () => {
+      expect(newExtensions).not.toContain(secret)
     })
   })
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -50,6 +50,7 @@ export const pageQuery = graphql`
           categories
           guide
           built_with_quarkus_core
+          unlisted
         }
         platforms
       }

--- a/src/templates/extension-detail-page.test.js
+++ b/src/templates/extension-detail-page.test.js
@@ -47,6 +47,11 @@ describe("extension detail page", () => {
       const link = links.find(link => link.href === guideUrl)
       expect(link).toBeTruthy()
     })
+
+    it("does not render an unlisted banner", async () => {
+      const link = await screen.queryByText(/nlisted/)
+      expect(link).toBeNull()
+    })
   })
 
   describe("for an extension with very little information", () => {
@@ -75,6 +80,31 @@ describe("extension detail page", () => {
     it("does not render anything about guides", async () => {
       const link = await screen.queryByText(/Documentation/)
       expect(link).toBeNull()
+    })
+  })
+
+  describe("for an unlisted extension", () => {
+    const previous = {}
+    const next = {}
+
+    const category = "secret-jewellery"
+    const extension = {
+      name: "Secret JRuby",
+      slug: "jruby-slug",
+      metadata: { categories: [category], unlisted: true },
+    }
+
+    beforeEach(() => {
+      render(
+        <ExtensionDetailTemplate
+          data={{ extension, previous, next }}
+          location="/somewhere"
+        />
+      )
+    })
+
+    it("renders an unlisted banner", () => {
+      expect(screen.getByText("Unlisted")).toBeTruthy()
     })
   })
 })

--- a/src/templates/extension-detail.js
+++ b/src/templates/extension-detail.js
@@ -24,6 +24,18 @@ const Headline = styled.header`
   display: flex;
   flex-direction: row;
   margin-bottom: 62px;
+  align-items: center;
+`
+
+const UnlistedWarning = styled.header`
+  padding-left: var(--a-boatload-of-space);
+  background-color: var(--grey-0);
+  text-align: left;
+  font-size: var(--font-size-24);
+  font-weight: var(--font-weight-bold);
+  color: var(--grey-2);
+  padding-top: var(--a-modest-space);
+  padding-bottom: var(--a-modest-space);
 `
 
 const Columns = styled.div`
@@ -105,6 +117,7 @@ const ExtensionDetailTemplate = ({
   return (
     <Layout location={location}>
       <BreadcrumbBar name={name} />
+      {metadata.unlisted && <UnlistedWarning>Unlisted</UnlistedWarning>}
       <ExtensionDetails>
         <Headline>
           <Logo>
@@ -205,6 +218,7 @@ export const pageQuery = graphql`
         status
         categories
         guide
+        unlisted
       }
     }
     previous: extension(id: { eq: $previousPostId }) {


### PR DESCRIPTION
Resolves #15.

- [x] Exclude unlisted extensions by default
- [x] Include unlisted extensions in text search results
- [x] Visual indicator of unlisted-ness on card view
- [x] Visual indicator of unlisted-ness on extension page

See discussion at https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/Listing.20unlisted.20extensions/near/310598347