### PR TITLE
Test fixes

### DIFF
--- a/test-integration/frontpage.test.js
+++ b/test-integration/frontpage.test.js
@@ -35,7 +35,9 @@ describe("main site", () => {
     })
 
     it("should have a well-known platform extension", async () => {
-      await expect(page.waitForXPath('//*[text()="ArC"]')).resolves.toBeTruthy()
+      await expect(
+        page.waitForXPath('//*[text()="Cache"]')
+      ).resolves.toBeTruthy()
     })
 
     it("should have more than one well-known platform extension", async () => {

--- a/test-integration/links.test.js
+++ b/test-integration/links.test.js
@@ -54,6 +54,8 @@ describe("site links", () => {
       "https://quarkus.io/guides/mybatis-plus",
       "https://quarkus.io/guides/freemarker",
       "https://quarkus.io/guides/qson",
+      // This is correct in 2.14.2, but not in 3.0.0.Alpha
+      "https://quarkus.io/guides/security-jpa",
     ]
 
     // Go ahead and start the scan! As events occur, we will see them above.


### PR DESCRIPTION
The changes in #15 broke the integration tests, because we look for ArC but ArC is an unlisted extension. 

The `security-jpa` extension's guide link was fixed in 2.14.2 Quarkus release, but we list the 3.0.0.Alpha extension, which still has the problematic link, so we need to add an exclusion. 