### PR TITLE
Error tolerance: download backup image to keep remote images plugin happy

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -28,6 +28,12 @@ module.exports = {
       options: {
         nodeType: "extension",
         imagePath: "fields.sourceControlInfo.logoUrl",
+        // It's kind of wasteful to download images if we don't have an image to download, but there doesn't seem to be a way to get the plugin not to try to download empty URLs
+        // See https://github.com/graysonhicks/gatsby-plugin-remote-images/issues/120
+        prepareUrl: url =>
+          url
+            ? url
+            : "https://avatars.githubusercontent.com/u/69191779?s=200&v=4",
       },
     },
     {


### PR DESCRIPTION
I'm seeing errors in the logs (bad) and inconsistent data in the UI (terrible), because of the remote images plugin not tolerating missing images. I've raised https://github.com/graysonhicks/gatsby-plugin-remote-images/issues/120, but as a workaround, I think we need to always download an image. 

We don't have to use the image, but for the moment I'm using the Quarkiverse image and using it. Therefore, by happy chance, this resolves #41.  