### PR TITLE
Improve maven tolerance

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -139,6 +139,7 @@ exports.createSchemaCustomization = ({ actions }) => {
     type MavenInfo {
       url: String
       version: String
+      timestamp: Int
     }
     
     

--- a/gatsby-node.test.js
+++ b/gatsby-node.test.js
@@ -133,7 +133,7 @@ describe("the main gatsby entrypoint", () => {
     })
   })
 
-  // in a handful of the extension yamls, the unlisted is a string, not a boolean. since this is a string, it drives graphQL made with type anxiety, unless we help.
+  // in a handful of the extension yamls, the unlisted is a string, not a boolean. since this is a string, it drives graphQL mad with type anxiety, unless we help.
   describe("for an extension with unlisted as a string", () => {
     const extension = { metadata: { unlisted: "true" } }
 

--- a/src/maven/maven-url.js
+++ b/src/maven/maven-url.js
@@ -14,6 +14,8 @@ const createMavenUrlFromCoordinates = async coordinates => {
   const exists = await urlExist(url)
   if (exists) {
     return url
+  } else {
+    console.warn("Could not work out url. Best guess was ", url)
   }
 }
 


### PR DESCRIPTION
We're seeing a lot of problems where maven central is returning 504s when we try and confirm URLs exist and get release timestamps, This is only a minor workaround, but take steps to make sure that maven errors don't confuse gatsby.