### PR TITLE
Move to maven-central-style path formatting 

### DIFF
--- a/src/components/util/extension-slugger.js
+++ b/src/components/util/extension-slugger.js
@@ -1,20 +1,28 @@
 const parse = require("mvn-artifact-name-parser").default
 const slugify = require("slugify")
 
+const slugifyPart = string => {
+  return slugify(string, {
+    lower: true,
+  })
+}
+
 const extensionSlug = gav => {
   if (gav) {
     let string
     if (gav.includes(":")) {
       const coordinates = parse(gav)
-      string = coordinates.groupId + "_" + coordinates.artifactId
+      // slugs can have slashes in them, so use folders to group extensions in the same group
+      // slugify strips slashes, so slugify before adding the slashes
+      string =
+        slugifyPart(coordinates.groupId) +
+        "/" +
+        slugifyPart(coordinates.artifactId)
     } else {
-      string = gav
+      string = slugifyPart(gav)
     }
-    // We don't want dots in the url even though they are technically allowed
-    const deDotted = string.replace(/\./g, "-")
-    return slugify(deDotted, {
-      lower: true,
-    })
+
+    return string
   }
 }
 module.exports = { extensionSlug }

--- a/src/components/util/extension-slugger.test.js
+++ b/src/components/util/extension-slugger.test.js
@@ -10,20 +10,20 @@ describe("extension url generator", () => {
   })
 
   it("handles non-platform platforms", () => {
-    expect(extensionSlug("io.quarkus:my.nice.id:2.0.7:json:1.0-SNAPSHOT")).toBe(
-      "io-quarkus_my-nice-id"
+    expect(extensionSlug("io.quarkus:my-nice-id:2.0.7:json:1.0-SNAPSHOT")).toBe(
+      "io.quarkus/my-nice-id"
     )
   })
 
   it("handles arbitrary GAVs", () => {
     expect(extensionSlug("something:else:number:whatever:still")).toBe(
-      "something_else"
+      "something/else"
     )
   })
 
   it("lower cases urls", () => {
     expect(extensionSlug("Something:else:number:whatever:still")).toBe(
-      "something_else"
+      "something/else"
     )
   })
 })


### PR DESCRIPTION
That is, more folders, fewer dashes and underscores. I thought this would create problems in implementation and interpretation, but I implemented it, and maven central use the same convention, so interpretation should also be fine.

Fixes #52