### PR TITLE
Correct case of name of extension type to be consistent

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -26,7 +26,7 @@ module.exports = {
     {
       resolve: `gatsby-plugin-remote-images`,
       options: {
-        nodeType: "extension",
+        nodeType: "Extension",
         imagePath: "fields.sourceControlInfo.logoUrl",
         // See https://github.com/graysonhicks/gatsby-plugin-remote-images/issues/120
         // The plugin complains about null logoUrl fields

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -24,7 +24,7 @@ exports.sourceNodes = async ({
       sortableName: sortableName(extension.name),
       slug: extensionSlug(extension.artifact),
       internal: {
-        type: "extension",
+        type: "Extension",
         contentDigest: createContentDigest(extension),
       },
       platforms: extension.origins?.map(origin => getPlatformId(origin)),
@@ -97,30 +97,12 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
   }
 }
 
-exports.onCreateNode = ({ node, actions }) => {
-  const { createNodeField } = actions
-
-  // TODO why doesn't this work, so we have to do it in the create call?
-  if (node.internal.type === `Extension`) {
-    const value = slugger.slug(node.name, false)
-
-    createNodeField({
-      name: `slug`,
-      node,
-      value,
-    })
-  }
-}
-
 exports.createSchemaCustomization = ({ actions }) => {
   const { createTypes } = actions
 
-  // Explicitly define the siteMetadata {} object
-  // This way those will always be defined even if removed from gatsby-config.js
-
   createTypes(`
   
-    type Extension {
+    type Extension implements Node {
       name: String!
       description: String
       slug: String!
@@ -141,22 +123,6 @@ exports.createSchemaCustomization = ({ actions }) => {
       version: String
       timestamp: Int
     }
-    
-    
-    type SiteSiteMetadata {
-      author: Author
-      siteUrl: String
-      social: Social
-    }
-
-    type Author {
-      name: String
-      summary: String
-    }
-
-    type Social {
-      twitter: String
-    }
-
+ 
   `)
 }

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -121,8 +121,9 @@ exports.createSchemaCustomization = ({ actions }) => {
     type MavenInfo {
       url: String
       version: String
-      timestamp: Int
+      timestamp: String
     }
  
   `)
+  // We use string to represent the timestamp, because otherwise we risk bursting the 32-bit integer limit in graphql
 }

--- a/plugins/github-enricher/gatsby-node.js
+++ b/plugins/github-enricher/gatsby-node.js
@@ -1,7 +1,7 @@
 const gh = require("parse-github-url")
 
 const defaultOptions = {
-  nodeType: "extension",
+  nodeType: "Extension",
 }
 
 exports.onCreateNode = async ({ node, getNode, actions }, pluginOptions) => {

--- a/plugins/github-enricher/gatsby-node.test.js
+++ b/plugins/github-enricher/gatsby-node.test.js
@@ -9,7 +9,7 @@ const createNodeField = jest.fn(({ node, name, value }) => {
   node.fields[name] = value
 })
 const actions = { createNodeField }
-const internal = { type: "extension" }
+const internal = { type: "Extension" }
 
 describe("the preprocessor", () => {
   describe("for an extension with no scm information", () => {

--- a/src/templates/extension-detail.js
+++ b/src/templates/extension-detail.js
@@ -177,7 +177,7 @@ const ExtensionDetailTemplate = ({
                 text: metadata.maven?.timestamp,
                 transformer: timestamp =>
                   timestamp
-                    ? format(new Date(timestamp), "MMM dd, yyyy")
+                    ? format(new Date(+timestamp), "MMM dd, yyyy")
                     : "unknown",
               }}
             />


### PR DESCRIPTION
Changed the type of the ‘extension’ nodes I was creating to ‘Extension’, since type names should be Pascal case. This means the type is actually applied, instead of being defined but never applied to the nodes I was creating.

This rippled through quite a few places in the codebase. The main effect of this is that all the schema I was defining actually are applied to the extension nodes.

A code path that wasn’t being traversed, for reasons I couldn’t figure out, now is being traversed. It turned out to not be a great way of doing the thing, so I removed it. I also removed a bit of clutter from the starter.