### PR TITLE
Tidy comments

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -22,9 +22,6 @@ module.exports = {
         nodeType: "SourceControlInfo",
         imagePath: "ownerImageUrl",
         name: "ownerImage",
-        // See https://github.com/graysonhicks/gatsby-plugin-remote-images/issues/120
-        // The plugin complains about null ownerImageUrl fields
-        silent: true,
       },
     },
     `gatsby-plugin-image`,


### PR DESCRIPTION
Now that #59 is fixed, we can remove comments about it. Error suppression never seemed to work, but we probably don't want it. 