### PR TITLE
Use undefined for unknown maven timestamp 

### DIFF
--- a/src/maven/maven-info.js
+++ b/src/maven/maven-info.js
@@ -40,8 +40,7 @@ const generateMavenInfo = async artifact => {
     }
   })
 
-  // Error tolerance; make sure something get sets even if maven central is playing up
-  maven.timestamp = timestamp ? timestamp : 0
+  maven.timestamp = timestamp
 
   return maven
 }

--- a/src/maven/maven-info.test.js
+++ b/src/maven/maven-info.test.js
@@ -67,7 +67,7 @@ describe("the maven information generator", () => {
       "(this is a deliberate error to exercise the error path)"
     )
     const mavenInfo = await generateMavenInfo(artifact)
-    expect(mavenInfo.timestamp).toBe(0)
+    expect(mavenInfo.timestamp).toBeUndefined()
 
     // Other information should be present and correct
     expect(mavenInfo.version).toBe("3.0.0.Alpha1")

--- a/src/templates/extension-detail-page.test.js
+++ b/src/templates/extension-detail-page.test.js
@@ -27,7 +27,7 @@ describe("extension detail page", () => {
         maven: {
           version,
           url: mvnUrl,
-          timestamp: 1666716560000,
+          timestamp: "1666716560000",
         },
         sourceControl: {
           url: gitUrl,


### PR DESCRIPTION
Now that we are using the type hierarchy as intended, we can stop setting a dummy value for maven timestamps; it gets rendered as 1970, which looks silly :)