### PR TITLE
Check for logo key when deciding image, consolidate image selection logic

### DIFF
--- a/__mocks__/gatsby-plugin-image.js
+++ b/__mocks__/gatsby-plugin-image.js
@@ -1,14 +1,31 @@
 const React = require("react")
 const plugin = jest.requireActual("gatsby-plugin-image")
 
-const mockImage = ({ imgClassName, ...props }) =>
+const mockStaticImage = ({ imgClassName, ...props }) =>
   React.createElement("img", {
     ...props,
     className: imgClassName,
   })
 
+const mockGatsbyImage = ({ imgClassName, ...props }) =>
+  React.createElement("img", {
+    ...props?.image?.props,
+    alt: props?.alt,
+    className: imgClassName,
+  })
+
 module.exports = {
   ...plugin,
-  GatsbyImage: jest.fn().mockImplementation(mockImage),
-  StaticImage: jest.fn().mockImplementation(mockImage),
+  GatsbyImage: jest.fn().mockImplementation(mockGatsbyImage),
+  StaticImage: jest.fn().mockImplementation(mockStaticImage),
+  // For ease of testing, have getImage just return back the un-nested object we give it
+  getImage: jest.fn().mockImplementation(obj =>
+    obj?.childImageSharp?.gatsbyImageData
+      ? {
+          props: {
+            src: obj?.childImageSharp?.gatsbyImageData,
+          },
+        }
+      : undefined
+  ),
 }

--- a/src/components/extension-card.js
+++ b/src/components/extension-card.js
@@ -3,7 +3,7 @@ import Link from "gatsby-link"
 
 import styled from "styled-components"
 import prettyCategory from "./util/pretty-category"
-import { GatsbyImage, getImage, StaticImage } from "gatsby-plugin-image"
+import ExtensionImage from "./extension-image"
 
 const Card = styled(props => <Link {...props} />)`
   font-size: 3.5em;
@@ -69,32 +69,11 @@ const FinerDetails = styled.div`
 `
 
 const Logo = ({ extension }) => {
-  const imageData = getImage(extension.metadata.sourceControl?.projectImage)
-    ? getImage(extension.metadata.sourceControl?.projectImage)
-    : getImage(extension.metadata.sourceControl?.ownerImage)
-
-  if (imageData) {
-    return (
-      <LogoImage>
-        <GatsbyImage
-          layout="constrained"
-          image={imageData}
-          alt="The extension logo"
-        />
-      </LogoImage>
-    )
-  } else {
-    return (
-      <LogoImage>
-        <StaticImage
-          layout="constrained"
-          formats={["auto", "webp", "avif"]}
-          src="../images/generic-extension-logo.png"
-          alt="A generic image as a placeholder for the extension logo"
-        />
-      </LogoImage>
-    )
-  }
+  return (
+    <LogoImage>
+      <ExtensionImage extension={extension} />
+    </LogoImage>
+  )
 }
 
 const ExtensionCard = ({ extension }) => {

--- a/src/components/extension-image.js
+++ b/src/components/extension-image.js
@@ -1,0 +1,35 @@
+import * as React from "react"
+import { GatsbyImage, getImage, StaticImage } from "gatsby-plugin-image"
+
+const ExtensionImage = ({ extension }) => {
+  const metadata = extension.metadata
+  const sourceControl = metadata.sourceControl
+
+  let imageData
+  let altText
+  if (metadata && metadata["icon-url"]) {
+    imageData = getImage(metadata["icon-url"])
+    altText = "The logo of the project"
+  } else if (sourceControl?.projectImage) {
+    imageData = getImage(sourceControl.projectImage)
+    altText = "The logo of the project"
+  } else if (sourceControl?.ownerImage) {
+    imageData = getImage(sourceControl.ownerImage)
+    altText = "The logo of the organisation"
+  }
+
+  if (imageData) {
+    return <GatsbyImage layout="constrained" image={imageData} alt={altText} />
+  } else {
+    return (
+      <StaticImage
+        layout="constrained"
+        formats={["auto", "webp", "avif"]}
+        src="../images/generic-extension-logo.png"
+        alt="A generic image as a placeholder for the extension logo"
+      />
+    )
+  }
+}
+
+export default ExtensionImage

--- a/src/components/extension-image.test.js
+++ b/src/components/extension-image.test.js
@@ -1,0 +1,118 @@
+import { render, screen } from "@testing-library/react"
+import React from "react"
+import ExtensionImage from "./extension-image"
+
+describe("the extension image", () => {
+  describe("when no image is available", () => {
+    const extension = {
+      metadata: {},
+    }
+
+    beforeEach(() => {
+      render(<ExtensionImage extension={extension} />)
+    })
+
+    it("renders a generic static image with suitable alt text", () => {
+      const image = screen.getByAltText(
+        "A generic image as a placeholder for the extension logo"
+      )
+      expect(image).toBeTruthy()
+    })
+
+    it("renders the placeholder image", () => {
+      const image = screen.getByRole("img")
+      expect(image.src).toContain("generic-extension-logo.png")
+    })
+  })
+
+  describe("when there is an owner image", () => {
+    const extension = {
+      metadata: {
+        sourceControl: {
+          ownerImage: {
+            childImageSharp: {
+              gatsbyImageData: "owner-logo.png",
+            },
+          },
+        },
+      },
+    }
+
+    beforeEach(() => {
+      render(<ExtensionImage extension={extension} />)
+    })
+
+    it("renders the owner image", () => {
+      const image = screen.getByRole("img")
+      expect(image.src).toContain("owner-logo.png")
+    })
+  })
+
+  describe("when there is a social media preview", () => {
+    const extension = {
+      metadata: {
+        sourceControl: {
+          projectImage: {
+            childImageSharp: {
+              gatsbyImageData: "social-logo.png",
+            },
+          },
+          ownerImage: {
+            childImageSharp: {
+              gatsbyImageData: "owner-logo.png",
+            },
+          },
+        },
+      },
+    }
+
+    beforeEach(() => {
+      render(<ExtensionImage extension={extension} />)
+    })
+
+    it("renders the owner alt text", () => {
+      const image = screen.getByAltText("The logo of the project")
+      expect(image).toBeTruthy()
+    })
+
+    it("renders the owner image", () => {
+      const image = screen.getByRole("img", {})
+
+      expect(image.src).toContain("social-logo.png")
+    })
+  })
+
+  describe("when the image is set in the metadata", () => {
+    const extension = {
+      metadata: {
+        "icon-url": {
+          childImageSharp: {
+            gatsbyImageData: "yaml-logo.png",
+          },
+        },
+        sourceControl: {
+          projectImage: {
+            childImageSharp: {
+              gatsbyImageData: "social-logo.png",
+            },
+          },
+          ownerImage: {
+            childImageSharp: {
+              gatsbyImageData: "owner-logo.png",
+            },
+          },
+        },
+      },
+    }
+
+    beforeEach(() => {
+      render(<ExtensionImage extension={extension} />)
+    })
+
+    it("renders the owner image", () => {
+      const image = screen.getByRole("img", {})
+
+      expect(image.src).toContain("yaml-logo.png")
+    })
+  })
+})

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -54,6 +54,11 @@ export const pageQuery = graphql`
           maven {
             version
           }
+          logo {
+            childImageSharp {
+              gatsbyImageData(width: 220)
+            }
+          }
           sourceControl {
             projectImage {
               childImageSharp {

--- a/src/templates/extension-detail-page.test.js
+++ b/src/templates/extension-detail-page.test.js
@@ -124,7 +124,7 @@ describe("extension detail page", () => {
     })
 
     it("renders a logo with appropriate source ", async () => {
-      const image = screen.getByAltText("The extension logo")
+      const image = screen.getByAltText("The logo of the organisation")
 
       // We can't just read the source, because this is a gatsby container, not a raw image
       // The key names in the objects have UUIDs in them, so we cannot trivially inspect the object

--- a/src/templates/extension-detail.js
+++ b/src/templates/extension-detail.js
@@ -3,12 +3,12 @@ import { graphql, Link } from "gatsby"
 import { format } from "date-fns"
 import Layout from "../components/layout"
 import Seo from "../components/seo"
-import { GatsbyImage, getImage, StaticImage } from "gatsby-plugin-image"
 import styled from "styled-components"
 import BreadcrumbBar from "../components/extensions-display/breadcrumb-bar"
 import ExtensionMetadata from "../components/extensions-display/extension-metadata"
 import InstallationInstructions from "../components/extensions-display/installation-instructions"
 import { prettyPlatformName } from "../components/util/pretty-platform"
+import ExtensionImage from "../components/extension-image"
 
 const ExtensionDetails = styled.main`
   margin-left: var(--a-boatload-of-space);
@@ -108,32 +108,11 @@ const DocumentationHeading = styled.h2`
 `
 
 const Logo = ({ extension }) => {
-  const imageData = getImage(extension.metadata.sourceControl?.projectImage)
-    ? getImage(extension.metadata.sourceControl?.projectImage)
-    : getImage(extension.metadata.sourceControl?.ownerImage)
-
-  if (imageData) {
-    return (
-      <LogoImage>
-        <GatsbyImage
-          layout="constrained"
-          image={imageData}
-          alt="The extension logo"
-        />
-      </LogoImage>
-    )
-  } else {
-    return (
-      <LogoImage>
-        <StaticImage
-          layout="constrained"
-          formats={["auto", "webp", "avif"]}
-          src="../images/generic-extension-logo.png"
-          alt="A generic image as a placeholder for the extension logo"
-        />
-      </LogoImage>
-    )
-  }
+  return (
+    <LogoImage>
+      <ExtensionImage extension={extension} />
+    </LogoImage>
+  )
 }
 
 const ExtensionDetailTemplate = ({
@@ -291,6 +270,11 @@ export const pageQuery = graphql`
         categories
         guide
         unlisted
+        logo {
+          childImageSharp {
+            gatsbyImageData(width: 220)
+          }
+        }
         maven {
           version
           url


### PR DESCRIPTION
This PR resolves #23 (except for a bit of documentation), and adds support for reading an extension image from a `logo` key in the metadata of the extension yaml. I couldn't try it with a published extension, but I've tested it with a dummy metadata and confirmed the code paths work as intended.