### PR TITLE
Set up scheduled builds

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -6,6 +6,8 @@ on:
       [ main ]
   pull_request:
     types: [ opened, synchronize, reopened ]
+  schedule: ## Do a run daily, to refresh website content
+    - cron: '0 3 * * *'
 
 jobs:
   unit-test:


### PR DESCRIPTION
Since this site is static, we need to run regular builds to keep the content current. This sets up a daily build at 3am. 

@gsmet, I'd welcome your opinion on whether this seems like a good time of day and frequency (not too wasteful, but fresh enough?) ... and also on whether you think I got the syntax right.