### PR TITLE
Correct logo->icon-url key rename

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -40,10 +40,14 @@ exports.sourceNodes = async ({
       }
     }
 
-    if (node.metadata["icon-url"]) {
+    // Avoid dashes in property names, since they get converted to underscores in some places and it's error-prone
+    node.metadata.icon = node.metadata["icon-url"]
+    delete node.metadata["icon-url"]
+
+    if (node.metadata.icon) {
       await createRemoteFileNode({
-        url: node.metadata["icon-url"],
-        name: path.basename(node.metadata["icon-url"]),
+        url: node.metadata.icon,
+        name: path.basename(node.metadata.icon),
         parentNodeId: node.id,
         getCache,
         createNode,
@@ -137,7 +141,7 @@ exports.createSchemaCustomization = ({ actions }) => {
       unlisted: Boolean
       maven: MavenInfo
       sourceControl: SourceControlInfo @link(by: "url")
-      logo: File @link(by: "url")
+      icon: File @link(by: "url")
     }
     
     type MavenInfo {

--- a/src/components/extension-card.test.js
+++ b/src/components/extension-card.test.js
@@ -38,7 +38,7 @@ describe("extension card", () => {
 
     it("renders a placeholder image with appropriate source ", async () => {
       const image = screen.getByAltText(
-        "A generic image as a placeholder for the extension logo"
+        "A generic image as a placeholder for the extension icon"
       )
 
       expect(image.src).toContain("generic-extension-logo.png")

--- a/src/components/extension-image.js
+++ b/src/components/extension-image.js
@@ -7,15 +7,15 @@ const ExtensionImage = ({ extension }) => {
 
   let imageData
   let altText
-  if (metadata && metadata["icon-url"]) {
-    imageData = getImage(metadata["icon-url"])
-    altText = "The logo of the project"
+  if (metadata && metadata.icon) {
+    imageData = getImage(metadata.icon)
+    altText = "The icon of the project"
   } else if (sourceControl?.projectImage) {
     imageData = getImage(sourceControl.projectImage)
-    altText = "The logo of the project"
+    altText = "The icon of the project"
   } else if (sourceControl?.ownerImage) {
     imageData = getImage(sourceControl.ownerImage)
-    altText = "The logo of the organisation"
+    altText = "The icon of the organisation"
   }
 
   if (imageData) {
@@ -26,7 +26,7 @@ const ExtensionImage = ({ extension }) => {
         layout="constrained"
         formats={["auto", "webp", "avif"]}
         src="../images/generic-extension-logo.png"
-        alt="A generic image as a placeholder for the extension logo"
+        alt="A generic image as a placeholder for the extension icon"
       />
     )
   }

--- a/src/components/extension-image.test.js
+++ b/src/components/extension-image.test.js
@@ -14,7 +14,7 @@ describe("the extension image", () => {
 
     it("renders a generic static image with suitable alt text", () => {
       const image = screen.getByAltText(
-        "A generic image as a placeholder for the extension logo"
+        "A generic image as a placeholder for the extension icon"
       )
       expect(image).toBeTruthy()
     })
@@ -71,7 +71,7 @@ describe("the extension image", () => {
     })
 
     it("renders the owner alt text", () => {
-      const image = screen.getByAltText("The logo of the project")
+      const image = screen.getByAltText("The icon of the project")
       expect(image).toBeTruthy()
     })
 
@@ -85,7 +85,7 @@ describe("the extension image", () => {
   describe("when the image is set in the metadata", () => {
     const extension = {
       metadata: {
-        "icon-url": {
+        icon: {
           childImageSharp: {
             gatsbyImageData: "yaml-logo.png",
           },

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -54,7 +54,7 @@ export const pageQuery = graphql`
           maven {
             version
           }
-          logo {
+          icon {
             childImageSharp {
               gatsbyImageData(width: 220)
             }

--- a/src/templates/extension-detail-page.test.js
+++ b/src/templates/extension-detail-page.test.js
@@ -123,8 +123,8 @@ describe("extension detail page", () => {
       expect(screen.getByText("839")).toBeTruthy()
     })
 
-    it("renders a logo with appropriate source ", async () => {
-      const image = screen.getByAltText("The logo of the organisation")
+    it("renders an icon with appropriate source ", async () => {
+      const image = screen.getByAltText("The icon of the organisation")
 
       // We can't just read the source, because this is a gatsby container, not a raw image
       // The key names in the objects have UUIDs in them, so we cannot trivially inspect the object
@@ -206,7 +206,7 @@ describe("extension detail page", () => {
 
     it("renders a placeholder image with appropriate source ", async () => {
       const image = screen.getByAltText(
-        "A generic image as a placeholder for the extension logo"
+        "A generic image as a placeholder for the extension icon"
       )
 
       expect(image.src).toContain("generic-extension-logo.png")

--- a/src/templates/extension-detail.js
+++ b/src/templates/extension-detail.js
@@ -270,7 +270,7 @@ export const pageQuery = graphql`
         categories
         guide
         unlisted
-        logo {
+        icon {
           childImageSharp {
             gatsbyImageData(width: 220)
           }


### PR DESCRIPTION
When I was testing for SVG support, I spotted that I hadn’t got the key rename from ‘logo’ to ‘icon-url’ as correct as I’d thought, so I’ve fixed that. 
