### PR TITLE
Support SVG images defined in metadata

### DIFF
--- a/src/components/extension-card.js
+++ b/src/components/extension-card.js
@@ -71,7 +71,7 @@ const FinerDetails = styled.div`
 const Logo = ({ extension }) => {
   return (
     <LogoImage>
-      <ExtensionImage extension={extension} />
+      <ExtensionImage extension={extension} size={80} />
     </LogoImage>
   )
 }

--- a/src/components/extension-image.js
+++ b/src/components/extension-image.js
@@ -1,14 +1,17 @@
 import * as React from "react"
 import { GatsbyImage, getImage, StaticImage } from "gatsby-plugin-image"
 
-const ExtensionImage = ({ extension }) => {
+const ExtensionImage = ({ extension, size }) => {
   const metadata = extension.metadata
   const sourceControl = metadata.sourceControl
 
-  let imageData
+  let imageData, svgData
   let altText
   if (metadata && metadata.icon) {
     imageData = getImage(metadata.icon)
+    if (!imageData) {
+      svgData = metadata.icon.publicURL
+    }
     altText = "The icon of the project"
   } else if (sourceControl?.projectImage) {
     imageData = getImage(sourceControl.projectImage)
@@ -17,8 +20,9 @@ const ExtensionImage = ({ extension }) => {
     imageData = getImage(sourceControl.ownerImage)
     altText = "The icon of the organisation"
   }
-
-  if (imageData) {
+  if (svgData) {
+    return <img src={svgData} alt={altText} height={size} width={size} />
+  } else if (imageData) {
     return <GatsbyImage layout="constrained" image={imageData} alt={altText} />
   } else {
     return (

--- a/src/components/extension-image.test.js
+++ b/src/components/extension-image.test.js
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react"
+import { cleanup, render, screen } from "@testing-library/react"
 import React from "react"
 import ExtensionImage from "./extension-image"
 
@@ -113,6 +113,40 @@ describe("the extension image", () => {
       const image = screen.getByRole("img", {})
 
       expect(image.src).toContain("yaml-logo.png")
+    })
+
+    describe("when the image is an svg", () => {
+      const extension = {
+        metadata: {
+          icon: {
+            childImageSharp: null,
+            publicURL: "some-svg.svg",
+          },
+          sourceControl: {
+            projectImage: {
+              childImageSharp: {
+                gatsbyImageData: "social-logo.png",
+              },
+            },
+            ownerImage: {
+              childImageSharp: {
+                gatsbyImageData: "owner-logo.png",
+              },
+            },
+          },
+        },
+      }
+
+      beforeEach(() => {
+        cleanup()
+        render(<ExtensionImage extension={extension} />)
+      })
+
+      it("renders the owner image", () => {
+        const image = screen.getByRole("img", {})
+
+        expect(image.src).toContain("some-svg.svg")
+      })
     })
   })
 })

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -56,8 +56,9 @@ export const pageQuery = graphql`
           }
           icon {
             childImageSharp {
-              gatsbyImageData(width: 220)
+              gatsbyImageData(width: 80)
             }
+            publicURL
           }
           sourceControl {
             projectImage {

--- a/src/templates/extension-detail.js
+++ b/src/templates/extension-detail.js
@@ -110,7 +110,7 @@ const DocumentationHeading = styled.h2`
 const Logo = ({ extension }) => {
   return (
     <LogoImage>
-      <ExtensionImage extension={extension} />
+      <ExtensionImage extension={extension} size={220} />
     </LogoImage>
   )
 }
@@ -274,6 +274,7 @@ export const pageQuery = graphql`
           childImageSharp {
             gatsbyImageData(width: 220)
           }
+          publicURL
         }
         maven {
           version


### PR DESCRIPTION
While looking at https://github.com/quarkusio/quarkus/pull/30459, @maxandersen and @gsmet asked about SVG support. I had to test SVG support, since I’m relying on the framework for image processing. By default, SVG doesn’t work, so I’ve added some extra implementation to support it. 

This only covers the case where the image is set in the extension yaml. If we’re getting the image from GitHub, they have their own rules, which exclude SVG. 

 I followed the hints in https://stackoverflow.com/questions/53628498/gatsby-image-svg-not-found. Using a raw `<img` tag feels a bit odd, but 
https://stackoverflow.com/questions/71665446/how-to-render-svg-files-with-gatsby-image confirms it’s a sensible thing to do. (The react plugin is solving a different problem to what we have.)

To increase the chances of the svg being rendered at the right size, I set a size explicitly on the image itself; I'm not going to be able to tamper with the viewbox of the SVG itself, but `<img` size should work on most browsers except maybe IE. In my testing, it displayed fine even without the size, I assume because we're usually shrinking it from larger originals.
