### PR TITLE
Use group id and name from gav for extension ids 

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -20,12 +20,14 @@ exports.sourceNodes = async ({
 
   // Do a map so we can wait
   const promises = data.extensions.map(async extension => {
+    const slug = extensionSlug(extension.artifact)
+    const id = createNodeId(slug)
     const node = {
       metadata: {},
       ...extension,
-      id: createNodeId(extension.name),
+      id,
       sortableName: sortableName(extension.name),
-      slug: extensionSlug(extension.artifact),
+      slug,
       internal: {
         type: "Extension",
         contentDigest: createContentDigest(extension),

--- a/src/components/extensions-list.js
+++ b/src/components/extensions-list.js
@@ -38,7 +38,7 @@ const ExtensionsList = ({ extensions }) => {
         <Extensions>
           {filteredExtensions.map(extension => {
             return (
-              <li key={extension.name}>
+              <li key={extension.id}>
                 <ExtensionCard extension={extension} />
               </li>
             )


### PR DESCRIPTION
We already turn this into a slug, so we can use the slug, which is unique, for the extension id, instead of the name, which is not unique.

Resolves #73 