### PR TITLE
Update hero bar to main site style

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -2,7 +2,7 @@ module.exports = {
   pathPrefix: "extensions.quarkus.io",
 
   siteMetadata: {
-    title: `Welcome to the Quarkiverse`,
+    title: `Extensions`,
     author: {
       name: `The Quarkus Team`,
       summary: `who are nice.`,

--- a/src/components/hero-bar.js
+++ b/src/components/hero-bar.js
@@ -4,31 +4,48 @@ import styled from "styled-components"
 
 const HeroBart = styled.header`
   height: 300px;
+  padding-left: var(--a-boatload-of-space);
+  padding-right: var(--a-boatload-of-space);
   color: var(--white);
   text-align: left;
   font-size: var(--font-size-28);
   opacity: 1;
   margin: 0;
-  background-color: var(--quarkus-blue);
+  background-color: var(--dark-blue-alt);
   display: flex;
   flex-direction: column;
   justify-content: space-evenly;
-  align-items: center;
+  align-items: flex-start;
+  padding-top: 4rem;
+  padding-bottom: 3rem;
 `
 
 const Heroic = styled.h1`
-  font-size: var(--font-size-72);
-  margin: 0;
-  font-weight: var(--font-weight-normal);
-  text-transform: uppercase;
-  letter-spacing: 12.96px;
+  font-size: var(--font-size-48);
+  line-height: 3.75rem;
+  font-weight: 700;
+  margin: 2.5rem 0 1.5rem 0;
+`
+
+const Modest = styled.h3`
+  font-size: var(--font-size-24);
+  line-height: 1.8rem;
+  font-weight: 400;
+  margin: 2.5rem 0 1.5rem 0;
 `
 
 const StyledLink = styled.a`
+  font-size: var(--font-size-20);
+  line-height: 1.8rem;
+  font-weight: 400;
   text-decoration: underline;
   color: var(--white);
-  margin-left: var(--a-small-space);
-  margin-right: var(--a-small-space);
+`
+
+const Links = styled.div`
+  display: flex;
+  gap: 1rem;
+  margin: 2.5rem 0 1.5rem 0;
 `
 
 const HeroBar = ({ title }) => {
@@ -36,19 +53,19 @@ const HeroBar = ({ title }) => {
     <div>
       <HeroBart>
         <Heroic>{title}</Heroic>
-        <span>
-          Your home for community created extensions that broaden the reach and
-          capabilities of Quarkus.
-        </span>
-        <span>
+        <Modest>
+          A Quarkiverse of extensions enhance your application just as project
+          dependencies do.
+        </Modest>
+        <Links>
           <StyledLink href="https://quarkus.io/faq/#what-is-a-quarkus-extension">
             What are Extensions?
           </StyledLink>
-          |
+          <span>|</span>
           <StyledLink href="https://access.redhat.com/documentation/en-us/red_hat_build_of_quarkus/1.3/html/developing_and_compiling_your_quarkus_applications_with_apache_maven/proc-installing-and-managing-java-extensions-with-quarkus-applications_quarkus-maven#doc-wrapper">
             How do I use them?
           </StyledLink>
-        </span>
+        </Links>
       </HeroBart>
     </div>
   )

--- a/test-integration/frontpage.test.js
+++ b/test-integration/frontpage.test.js
@@ -17,7 +17,7 @@ describe("main site", () => {
 
   it("should have Quarkiverse on it somewhere", async () => {
     await expect(
-      page.waitForXPath(`//*[text()="Welcome to the Quarkiverse"]`)
+      page.waitForXPath(`//*[text()="Extensions"]`)
     ).resolves.toBeTruthy()
   })
 


### PR DESCRIPTION
This updates the hero bar to the style used on the main site, in partial resolution of #47. @insectengine says the hero bars may be going away across the whole site, so this section of code may be short-lived anyway.  